### PR TITLE
API Contract & Request Validation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ def health_check():
     return {"status": "healthy"}
 
 
+# Governing: SPEC-0002 REQ "API Contract", ADR-0002
 @app.post('/api/reconcile/medication', response_model=ReconciliationResult)
 def reconcile_medication(record: PatientRecord) -> ReconciliationResult:
     """
@@ -57,6 +58,9 @@ def reconcile_medication(record: PatientRecord) -> ReconciliationResult:
     - Clinical safety check
     - Recommended actions
     """
+    if not record.sources:
+        raise HTTPException(status_code=422, detail="At least one medication source is required")
+
     try:
         # Convert Pydantic models to dicts for service processing
         patient_context = record.patient_context.model_dump() if hasattr(record.patient_context, 'model_dump') else record.patient_context.__dict__

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,12 +128,11 @@ class TestReconciliationAPI:
         }
         
         response = client.post("/api/reconcile/medication", json=payload)
-        assert response.status_code == 200
+        assert response.status_code == 422
         data = response.json()
-        
-        # Should return empty result, not crash
-        assert data["confidence_score"] == 0.0
-        assert data["clinical_safety_check"] == "REVIEW_REQUIRED"
+
+        # Should return a 422 error with a detail message
+        assert "detail" in data
 
     def test_reconcile_prefers_recent_renal_appropriate_metformin(self):
         """Select more recent, renal-appropriate metformin dose when eGFR is reduced."""


### PR DESCRIPTION
Implements SPEC-0002 REQ "API Contract": enforces 422 response for empty sources array and adds governing comments.

## Changes
- `backend/main.py`: Added 422 guard for empty `record.sources`; added `# Governing: SPEC-0002 REQ "API Contract", ADR-0002` comment
- `tests/test_api.py`: Updated `test_reconcile_no_sources_error_handling` to assert HTTP 422

## Acceptance Criteria
- [x] Per SPEC-0002 REQ "API Contract": endpoint accepts `PatientRecord` and returns all five fields
- [x] Per SPEC-0002 REQ "API Contract": empty `sources` returns 422 error, not a reconciliation result
- [x] Per SPEC-0002 REQ "API Contract": sources with no date fields are accepted with neutral recency score

Closes #2
Epic: #1
Spec: SPEC-0002 REQ "API Contract"