### PR TITLE
SQLAlchemy ORM & Data Layer (issue #12)

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -36,6 +36,12 @@ def create_app(config_name: str = "default") -> Flask:
     migrate.init_app(app, db)
     CORS(app)
 
+    # Import ORM models so Flask-Migrate (Alembic) discovers them during
+    # `flask db migrate` autogenerate. Must happen inside create_app() to
+    # avoid circular imports.
+    # Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer"
+    from . import models  # noqa: F401
+
     # Register one blueprint per domain (Governing: ADR-0001 blueprint-per-domain)
     from .api.health import health_bp
     from .api.reconciliation import reconciliation_bp

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,17 @@
+Flask-Migrate (Alembic) migration directory.
+
+After installing dependencies, initialise or apply migrations with:
+
+    # First time only (if env.py is missing):
+    flask db init
+
+    # Generate a migration from model changes:
+    flask db migrate -m "description"
+
+    # Apply all pending migrations:
+    flask db upgrade
+
+    # Roll back one revision:
+    flask db downgrade
+
+Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001

--- a/backend/migrations/alembic.ini
+++ b/backend/migrations/alembic.ini
@@ -1,0 +1,39 @@
+# Alembic configuration for Flask-Migrate.
+# Do not edit sqlalchemy.url — Flask-Migrate sets it from app config at runtime.
+
+[alembic]
+script_location = migrations
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,86 @@
+"""Alembic environment configuration for Flask-Migrate.
+
+Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+"""
+
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+from alembic import context
+
+# Alembic Config object — provides access to values in alembic.ini.
+config = context.config
+
+# Set up Python logging from alembic.ini.
+fileConfig(config.config_file_name)
+logger = logging.getLogger("alembic.env")
+
+
+def get_engine():
+    try:
+        return current_app.extensions["migrate"].db.get_engine()
+    except (TypeError, AttributeError):
+        return current_app.extensions["migrate"].db.engine
+
+
+def get_engine_url():
+    try:
+        return get_engine().url.render_as_string(hide_password=False).replace("%", "%%")
+    except AttributeError:
+        return str(get_engine().url).replace("%", "%%")
+
+
+# Point Alembic at the database URL from the running Flask app.
+config.set_main_option("sqlalchemy.url", get_engine_url())
+target_db = current_app.extensions["migrate"].db
+
+
+def get_metadata():
+    if hasattr(target_db, "metadatas"):
+        return target_db.metadatas[None]
+    return target_db.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations without an active database connection (URL only)."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=get_metadata(),
+        literal_binds=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations with an active database connection.
+
+    Flask-SQLAlchemy scopes the session per request; Alembic gets its
+    own engine connection here that is independent of the request session.
+    Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer" (session scoped per request).
+    """
+
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, "autogenerate", False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info("No schema changes detected — skipping empty migration.")
+
+    connectable = get_engine()
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=get_metadata(),
+            process_revision_directives=process_revision_directives,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/001_initial_clinical_schema.py
+++ b/backend/migrations/versions/001_initial_clinical_schema.py
@@ -1,0 +1,97 @@
+"""Initial clinical schema — patients, medications, reconciliation_results, data_quality_results.
+
+Revision ID: 001
+Revises:
+Create Date: 2026-04-07 00:00:00.000000
+
+Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create all clinical domain tables.
+
+    SPEC-0001 REQ "SQLAlchemy ORM Data Layer":
+      WHEN `flask db upgrade` is run against an empty database
+      THEN all tables are created without errors and the schema
+           matches the current ORM model definitions.
+    """
+    # --- patients ---
+    op.create_table(
+        "patients",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("age", sa.Integer(), nullable=True),
+        sa.Column("conditions", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # --- medications ---
+    op.create_table(
+        "medications",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=True),
+        sa.Column("system", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=500), nullable=False),
+        sa.Column("last_updated", sa.Date(), nullable=True),
+        sa.Column("last_filled", sa.Date(), nullable=True),
+        sa.Column("source_reliability", sa.String(length=10), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # --- reconciliation_results ---
+    # Stores hybrid-scored reconciliation output with timestamp + patient reference.
+    # SPEC-0001 REQ "SQLAlchemy ORM Data Layer": result MUST be saved with timestamp
+    # and patient reference.
+    op.create_table(
+        "reconciliation_results",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=True),
+        sa.Column("reconciled_medication", sa.String(length=500), nullable=False),
+        sa.Column("confidence_score", sa.Float(), nullable=False),
+        sa.Column("clinical_safety_check", sa.String(length=20), nullable=False),
+        sa.Column("reasoning", sa.Text(), nullable=True),
+        sa.Column("recommended_actions", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["patient_id"], ["patients.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # --- data_quality_results ---
+    op.create_table(
+        "data_quality_results",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=True),
+        sa.Column("overall_score", sa.Float(), nullable=False),
+        sa.Column("completeness", sa.Float(), nullable=False),
+        sa.Column("validity", sa.Float(), nullable=False),
+        sa.Column("consistency", sa.Float(), nullable=False),
+        sa.Column("timeliness", sa.Float(), nullable=False),
+        sa.Column("issues_detected", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["patient_id"], ["patients.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    """Drop all clinical domain tables in reverse dependency order."""
+    op.drop_table("data_quality_results")
+    op.drop_table("reconciliation_results")
+    op.drop_table("medications")
+    op.drop_table("patients")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,7 +1,14 @@
 """SQLAlchemy ORM models for the Clinical Data Reconciliation Engine.
 
-Models are implemented in issue #12 (SQLAlchemy ORM & Data Layer).
-The `db` instance used by all models is created in backend/__init__.py.
+Importing all models here ensures Flask-Migrate (Alembic) discovers them
+during `flask db migrate` autogenerate.  The `db` instance is created in
+backend/__init__.py and imported by each model module.
 
 Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
 """
+
+from .patient import Patient
+from .medication import Medication
+from .reconciliation import ReconciliationResult, DataQualityResult
+
+__all__ = ["Patient", "Medication", "ReconciliationResult", "DataQualityResult"]

--- a/backend/models/medication.py
+++ b/backend/models/medication.py
@@ -1,0 +1,40 @@
+"""Medication ORM model.
+
+Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+"""
+
+from datetime import datetime
+from backend import db
+
+
+class Medication(db.Model):
+    """Medication record sourced from a clinical system.
+
+    One row per source-medication pair within a reconciliation request.
+    Multiple Medication rows may reference the same Patient, each with
+    a different `system` origin (e.g. Hospital EMR, Pharmacy System).
+
+    Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer"
+    """
+
+    __tablename__ = "medications"
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer, db.ForeignKey("patients.id", ondelete="CASCADE"), nullable=True
+    )
+    # Source system name, e.g. "Hospital EMR", "Pharmacy System"
+    system = db.Column(db.String(255), nullable=False)
+    # Full medication string, e.g. "Metformin 500mg twice daily"
+    name = db.Column(db.String(500), nullable=False)
+    last_updated = db.Column(db.Date, nullable=True)
+    last_filled = db.Column(db.Date, nullable=True)
+    # One of: 'high', 'medium', 'low'
+    source_reliability = db.Column(db.String(10), nullable=False, default="medium")
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    # Relationships
+    patient = db.relationship("Patient", back_populates="medications")
+
+    def __repr__(self) -> str:
+        return f"<Medication id={self.id} system={self.system!r} name={self.name!r}>"

--- a/backend/models/patient.py
+++ b/backend/models/patient.py
@@ -1,0 +1,41 @@
+"""Patient ORM model.
+
+Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+"""
+
+from datetime import datetime
+from backend import db
+
+
+class Patient(db.Model):
+    """Clinical patient record.
+
+    Stores demographic context associated with reconciliation and data
+    quality evaluation requests.  PII is intentionally minimal — age
+    and conditions only.  Full identifiers are excluded per HIPAA
+    considerations documented in design.md.
+
+    Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer"
+    """
+
+    __tablename__ = "patients"
+
+    id = db.Column(db.Integer, primary_key=True)
+    age = db.Column(db.Integer, nullable=True)
+    # Stored as JSON array of strings, e.g. ["Type 2 Diabetes", "Hypertension"]
+    conditions = db.Column(db.JSON, nullable=True, default=list)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    # Relationships
+    medications = db.relationship(
+        "Medication", back_populates="patient", cascade="all, delete-orphan"
+    )
+    reconciliation_results = db.relationship(
+        "ReconciliationResult", back_populates="patient", cascade="all, delete-orphan"
+    )
+    data_quality_results = db.relationship(
+        "DataQualityResult", back_populates="patient", cascade="all, delete-orphan"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Patient id={self.id} age={self.age}>"

--- a/backend/models/patient.py
+++ b/backend/models/patient.py
@@ -27,14 +27,20 @@ class Patient(db.Model):
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     # Relationships
+    # Medications are owned by the patient — cascade delete is appropriate.
     medications = db.relationship(
         "Medication", back_populates="patient", cascade="all, delete-orphan"
     )
+    # Result rows use SET NULL on the FK (not CASCADE) so clinical audit history
+    # is preserved when a patient record is deleted.  ORM cascade must NOT include
+    # "delete" or "delete-orphan" here or SQLAlchemy will delete the rows before
+    # the DB-level SET NULL fires, destroying the audit trail.
+    # Governing: design.md HIPAA requirement "audit trails must be maintained"
     reconciliation_results = db.relationship(
-        "ReconciliationResult", back_populates="patient", cascade="all, delete-orphan"
+        "ReconciliationResult", back_populates="patient"
     )
     data_quality_results = db.relationship(
-        "DataQualityResult", back_populates="patient", cascade="all, delete-orphan"
+        "DataQualityResult", back_populates="patient"
     )
 
     def __repr__(self) -> str:

--- a/backend/models/reconciliation.py
+++ b/backend/models/reconciliation.py
@@ -1,0 +1,88 @@
+"""ReconciliationResult and DataQualityResult ORM models.
+
+Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+"""
+
+from datetime import datetime
+from backend import db
+
+
+class ReconciliationResult(db.Model):
+    """Persisted output of a medication reconciliation request.
+
+    Stores the winning medication, confidence score, safety check
+    outcome, and recommended clinical actions with a UTC timestamp
+    and optional patient reference.
+
+    SPEC-0001 REQ "SQLAlchemy ORM Data Layer" scenario:
+      WHEN the reconciliation service produces a result for a patient medication
+      THEN the result MUST be saved via this model with a timestamp and
+           patient reference.
+
+    Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+    """
+
+    __tablename__ = "reconciliation_results"
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer, db.ForeignKey("patients.id", ondelete="SET NULL"), nullable=True
+    )
+    # The reconciliation winner, e.g. "Metformin 500mg"
+    reconciled_medication = db.Column(db.String(500), nullable=False)
+    # 0.0–1.0 hybrid confidence score (ADR-0002: 60% det + 40% LLM)
+    confidence_score = db.Column(db.Float, nullable=False)
+    # One of: 'PASSED', 'FAILED', 'REVIEW_REQUIRED'
+    clinical_safety_check = db.Column(db.String(20), nullable=False)
+    reasoning = db.Column(db.Text, nullable=True)
+    # JSON array of action strings, e.g. ["Verify with prescriber", ...]
+    recommended_actions = db.Column(db.JSON, nullable=True, default=list)
+    # Timestamp required by SPEC-0001 REQ "SQLAlchemy ORM Data Layer"
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    # Relationship
+    patient = db.relationship("Patient", back_populates="reconciliation_results")
+
+    def __repr__(self) -> str:
+        return (
+            f"<ReconciliationResult id={self.id} "
+            f"medication={self.reconciled_medication!r} "
+            f"confidence={self.confidence_score:.2f}>"
+        )
+
+
+class DataQualityResult(db.Model):
+    """Persisted output of a data quality validation request.
+
+    Stores the four-dimension breakdown (completeness, validity,
+    consistency, timeliness) plus the weighted overall score and any
+    detected issues.
+
+    Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+    """
+
+    __tablename__ = "data_quality_results"
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer, db.ForeignKey("patients.id", ondelete="SET NULL"), nullable=True
+    )
+    # Overall quality score (0–100) per validation_service formula
+    overall_score = db.Column(db.Float, nullable=False)
+    # Individual dimension scores (0–100 each)
+    completeness = db.Column(db.Float, nullable=False)
+    validity = db.Column(db.Float, nullable=False)
+    consistency = db.Column(db.Float, nullable=False)
+    timeliness = db.Column(db.Float, nullable=False)
+    # JSON array of issue objects: [{field, issue, severity}, ...]
+    issues_detected = db.Column(db.JSON, nullable=True, default=list)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    # Relationship
+    patient = db.relationship("Patient", back_populates="data_quality_results")
+
+    def __repr__(self) -> str:
+        return (
+            f"<DataQualityResult id={self.id} "
+            f"overall={self.overall_score:.1f}>"
+        )


### PR DESCRIPTION
## Summary

Implements the database persistence layer for the Clinical Data Reconciliation Engine.

**ORM Models (`backend/models/`)**
- `patient.py` — `Patient` model: age, conditions (JSON), created_at; one-to-many relationships to medications, reconciliation results, and data quality results
- `medication.py` — `Medication` model: source system, medication name, last_updated, last_filled, source_reliability, FK → Patient with CASCADE delete
- `reconciliation.py` — `ReconciliationResult` model: reconciled_medication, confidence_score (0.0–1.0), clinical_safety_check (PASSED/FAILED/REVIEW_REQUIRED), reasoning, recommended_actions (JSON), **created_at timestamp + patient_id FK** (satisfies SPEC-0001 REQ "SQLAlchemy ORM Data Layer" persistence scenario); and `DataQualityResult` model: overall_score + four dimension scores + issues_detected (JSON)

**Migrations (`backend/migrations/`)**
- Full Flask-Migrate directory structure: `alembic.ini`, `env.py`, `script.py.mako`
- `versions/001_initial_clinical_schema.py` — creates all four tables; `flask db upgrade` runs cleanly against an empty database
- `downgrade()` implemented for all tables

**Session scoping**: Flask-SQLAlchemy's request teardown handles per-request session lifecycle automatically — no additional code required.

**`backend/__init__.py`**: imports `models` inside `create_app()` so Flask-Migrate autogenerate discovers all ORM classes.

## Acceptance Criteria

- [x] Per SPEC-0001 REQ "SQLAlchemy ORM Data Layer": `backend/models/patient.py`, `backend/models/medication.py`, `backend/models/reconciliation.py` define SQLAlchemy ORM classes
- [x] Per SPEC-0001 REQ "SQLAlchemy ORM Data Layer": `flask db upgrade` runs cleanly against an empty SQLite database — initial migration creates all four tables
- [x] Per SPEC-0001 REQ "SQLAlchemy ORM Data Layer": SQLAlchemy session scoped per request via Flask-SQLAlchemy's request teardown
- [x] Per SPEC-0001 REQ "SQLAlchemy ORM Data Layer": `ReconciliationResult` persists result with `created_at` timestamp and `patient_id` FK
- [x] Governing: ADR-0001 (Flask-SQLAlchemy + Flask-Migrate)

## Setup (after merging)

```bash
cd backend
pip install -r requirements.txt
flask db upgrade   # applies 001_initial_clinical_schema migration
```

Closes #12
Depends on: #11 (merged)
Part of #10
Spec: SPEC-0001 REQ "SQLAlchemy ORM Data Layer"
Governing: ADR-0001

🤖 Generated with [Claude Code](https://claude.com/claude-code)