### PR TITLE
Add SPEC-0003 governing comments and scenario tests for scoring engine

### DIFF
--- a/backend/validation_service/data_validator.py
+++ b/backend/validation_service/data_validator.py
@@ -2,16 +2,21 @@ from typing import Dict, List, Any, Optional
 from datetime import datetime, date
 from ..pydantic_models import Issue, Severity
 
+# Governing: SPEC-0003 REQ "API Contract", SPEC-0003 REQ "Overall Score Formula",
+#            SPEC-0003 REQ "Completeness Dimension", SPEC-0003 REQ "Validity Dimension",
+#            SPEC-0003 REQ "Consistency Dimension", SPEC-0003 REQ "Timeliness Dimension",
+#            SPEC-0003 REQ "Issue Object Schema"
+
 
 class DataValidator:
     """Validates clinical data quality across multiple dimensions."""
-    
+
     def __init__(self):
         self.required_fields = {
             "demographics.name": "high",
             "vital_signs": "medium"
         }
-    
+
     def validate_data_quality(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Validate patient data quality across four dimensions:
@@ -19,28 +24,29 @@ class DataValidator:
         - Validity (0-100)
         - Consistency (0-100)
         - Timeliness (0-100)
-        
+
         Returns a detailed quality assessment.
         """
         issues = []
-        
+
         # Check completeness
         completeness_score, completeness_issues = self._check_completeness(data)
         issues.extend(completeness_issues)
-        
+
         # Check validity
         validity_score, validity_issues = self._check_validity(data)
         issues.extend(validity_issues)
-        
+
         # Check consistency
         consistency_score, consistency_issues = self._check_consistency(data)
         issues.extend(consistency_issues)
-        
+
         # Check timeliness
         timeliness_score, timeliness_issues = self._check_timeliness(data)
         issues.extend(timeliness_issues)
-        
-        # Calculate overall score with stronger emphasis on completeness
+
+        # Governing: SPEC-0003 REQ "Overall Score Formula"
+        # overall_score = (avg_dimensions × 0.30) + (completeness × 0.70), clamped to [0, 100]
         base_average = (completeness_score + validity_score + consistency_score + timeliness_score) / 4
         overall_score = (base_average * 0.3) + (completeness_score * 0.7)
 
@@ -73,7 +79,9 @@ class DataValidator:
     def _check_completeness(self, data: Dict[str, Any]) -> tuple:
         """
         Check for missing required fields.
-        Score: 100 - (5 * number of missing critical fields)
+
+        Governing: SPEC-0003 REQ "Completeness Dimension"
+        Score starts at 100; each missing field subtracts a fixed penalty.
         """
         issues = []
         missing_critical = 0
@@ -178,6 +186,9 @@ class DataValidator:
     def _check_validity(self, data: Dict[str, Any]) -> tuple:
         """
         Check for invalid data formats and values.
+
+        Governing: SPEC-0003 REQ "Validity Dimension"
+        Score starts at 100; each invalid field subtracts a fixed penalty.
         """
         issues = []
         
@@ -249,7 +260,8 @@ class DataValidator:
         
         hr = vitals.get("heart_rate")
         if hr is not None:
-            if not isinstance(hr, int) or hr < 30 or hr > 200:
+            # Accept both int and float (Marshmallow deserializes heart_rate as Float)
+            if not isinstance(hr, (int, float)) or isinstance(hr, bool) or hr < 30 or hr > 200:
                 issues.append(Issue(
                     field="vital_signs.heart_rate",
                     issue=f"Heart rate value {hr} is outside normal range (30-200)",
@@ -293,6 +305,9 @@ class DataValidator:
     def _check_consistency(self, data: Dict[str, Any]) -> tuple:
         """
         Check for internal data consistency.
+
+        Governing: SPEC-0003 REQ "Consistency Dimension"
+        Score starts at 100; each inconsistency subtracts 15.
         """
         issues = []
         
@@ -350,6 +365,9 @@ class DataValidator:
     def _check_timeliness(self, data: Dict[str, Any]) -> tuple:
         """
         Check how recent the data is.
+
+        Governing: SPEC-0003 REQ "Timeliness Dimension"
+        Missing last_updated defaults to score=50 (neutral, medium severity).
         """
         issues = []
         

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -403,6 +403,129 @@ class TestValidationAPI:
         bp_issues = [i for i in data["issues_detected"] if i["field"] == "vital_signs.blood_pressure"]
         assert len(bp_issues) > 0
 
+    def test_future_dob_reduces_validity_by_20_high_severity(self):
+        """Governing: SPEC-0003 REQ "Validity Dimension" — future DOB MUST reduce validity by 20, severity high."""
+        payload = {
+            "demographics": {
+                "name": "Test Patient",
+                "dob": "2099-01-01",  # Far future date
+                "gender": "male"
+            },
+            "medications": ["Aspirin 81mg"],
+            "allergies": ["Penicillin"],
+            "conditions": ["Hypertension"],
+            "vital_signs": {
+                "blood_pressure": "120/80",
+                "heart_rate": 72,
+                "temperature": 37.0,
+                "respiratory_rate": None
+            },
+            "last_updated": "2026-04-01"  # Recent — avoids timeliness noise
+        }
+
+        response = client.post("/api/validate/data-quality", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Validity must be reduced by exactly 20 for future DOB (only validity issue in this payload)
+        assert data["breakdown"]["validity"] == 80
+        validity_dob_issues = [
+            i for i in data["issues_detected"]
+            if i["field"] == "demographics.dob" and "future" in i["issue"].lower()
+        ]
+        assert len(validity_dob_issues) > 0
+        assert validity_dob_issues[0]["severity"] == "high"
+
+    def test_missing_last_updated_timeliness_is_50_medium(self):
+        """Governing: SPEC-0003 REQ "Timeliness Dimension" — missing last_updated MUST yield timeliness=50, medium severity."""
+        payload = {
+            "demographics": {
+                "name": "Test Patient",
+                "dob": "1975-05-15",
+                "gender": "female"
+            },
+            "medications": ["Metformin 500mg"],
+            "allergies": ["Penicillin"],
+            "conditions": ["Type 2 Diabetes"],
+            "vital_signs": {
+                "blood_pressure": "120/80",
+                "heart_rate": 72,
+                "temperature": 37.0,
+                "respiratory_rate": None
+            }
+            # last_updated intentionally absent
+        }
+
+        response = client.post("/api/validate/data-quality", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["breakdown"]["timeliness"] == 50
+        timeliness_issues = [i for i in data["issues_detected"] if i["field"] == "last_updated"]
+        assert len(timeliness_issues) > 0
+        assert timeliness_issues[0]["severity"] == "medium"
+
+    def test_diabetes_without_medication_reduces_consistency(self):
+        """Governing: SPEC-0003 REQ "Consistency Dimension" — diabetes condition with no diabetes med MUST reduce consistency by 15."""
+        payload = {
+            "demographics": {
+                "name": "Test Patient",
+                "dob": "1960-03-10",
+                "gender": "male"
+            },
+            "medications": ["Lisinopril 10mg"],  # No diabetes medication
+            "allergies": ["Penicillin"],
+            "conditions": ["Type 2 Diabetes", "Hypertension"],
+            "vital_signs": {
+                "blood_pressure": "130/80",
+                "heart_rate": 72,
+                "temperature": 37.0,
+                "respiratory_rate": None
+            },
+            "last_updated": "2024-03-24"
+        }
+
+        response = client.post("/api/validate/data-quality", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["breakdown"]["consistency"] == 85  # 100 − 15
+        med_issues = [i for i in data["issues_detected"] if i["field"] == "medications"]
+        assert len(med_issues) > 0
+        assert med_issues[0]["severity"] == "low"
+
+    def test_overall_score_formula_is_completeness_weighted(self):
+        """Governing: SPEC-0003 REQ "Overall Score Formula" — overall = (avg × 0.30) + (completeness × 0.70).
+
+        Verifies: completeness=0, validity=100, consistency=100, timeliness=100
+        MUST yield overall = (75 × 0.30) + (0 × 0.70) = 22, not the naive average of 75.
+        """
+        # Use a payload with all required fields missing to drive completeness toward 0,
+        # and recent last_updated to keep timeliness=100.
+        payload = {
+            "demographics": {},
+            "medications": [],
+            "allergies": [],
+            "conditions": [],
+            "vital_signs": None,
+            "last_updated": "2026-04-01"  # Recent — timeliness = 100
+        }
+
+        response = client.post("/api/validate/data-quality", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify the formula is applied: overall = int((avg * 0.30) + (completeness * 0.70))
+        breakdown = data["breakdown"]
+        avg = (breakdown["completeness"] + breakdown["validity"] +
+               breakdown["consistency"] + breakdown["timeliness"]) / 4
+        expected = int((avg * 0.30) + (breakdown["completeness"] * 0.70))
+        assert data["overall_score"] == expected
+
+        # The overall score MUST be dominated by completeness, not a naive average.
+        # With completeness well below 100 and other dimensions higher, overall < avg.
+        assert data["overall_score"] < avg
+
 
 class TestAPIIntegration:
     """Integration tests for full workflow."""


### PR DESCRIPTION
## Summary

- Added `# Governing: SPEC-0003 REQ "..."` comments to all `DataValidator` methods, tracing the implementation to the spec's completeness, validity, consistency, timeliness, and overall-formula requirements
- Fixed a heart rate false-positive: Marshmallow deserializes `heart_rate` as `Float`, so `isinstance(hr, int)` was incorrectly flagging valid integer values (e.g., `72` → `72.0`). Updated check to accept `(int, float)`
- Added 4 new scenario tests covering SPEC-0003 acceptance criteria not previously verified:
  - `test_future_dob_reduces_validity_by_20_high_severity`
  - `test_missing_last_updated_timeliness_is_50_medium`
  - `test_diabetes_without_medication_reduces_consistency`
  - `test_overall_score_formula_is_completeness_weighted`

All 18 tests pass.

## Test plan

- [x] All 18 tests in `tests/test_api.py` pass
- [x] New scenario tests cover SPEC-0003 REQ "Validity Dimension", "Timeliness Dimension", "Consistency Dimension", "Overall Score Formula"
- [x] Governing comments present in `data_validator.py`

Closes #20
Part of #19
Governing: SPEC-0003

🤖 Generated with [Claude Code](https://claude.com/claude-code)