### PR TITLE
Add SPEC-0003 governing comments to validation API and schemas

### DIFF
--- a/backend/api/validation.py
+++ b/backend/api/validation.py
@@ -1,7 +1,9 @@
 """Validation blueprint — POST /api/validate/data-quality.
 
 Governing: SPEC-0001 REQ "Flask API Routes", SPEC-0001 REQ "API Endpoint Compatibility",
-           SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001
+           SPEC-0001 REQ "SQLAlchemy ORM Data Layer", ADR-0001,
+           SPEC-0003 REQ "API Contract", SPEC-0003 REQ "Issue Object Schema",
+           SPEC-0003 REQ "ORM Persistence"
 """
 
 from flask import jsonify, make_response
@@ -35,6 +37,8 @@ def validate_data_quality(args):
         result = _service.validate_data_quality(args)
         breakdown = result.get("breakdown", {})
 
+        # Governing: SPEC-0003 REQ "Issue Object Schema" — severity MUST be plain string
+        # ("high"/"medium"/"low"), never the Pydantic enum class name ("Severity.high")
         issues = [
             {
                 "field": issue.get("field", "unknown") if isinstance(issue, dict) else issue.field,
@@ -46,7 +50,8 @@ def validate_data_quality(args):
             for issue in result.get("issues_detected", [])
         ]
 
-        # Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer" — persist result with timestamp
+        # Governing: SPEC-0001 REQ "SQLAlchemy ORM Data Layer",
+        #            SPEC-0003 REQ "ORM Persistence" — persist result with UTC timestamp
         db_record = DataQualityResult(
             overall_score=float(result.get("overall_score", 0)),
             completeness=float(breakdown.get("completeness", 0)),
@@ -58,6 +63,8 @@ def validate_data_quality(args):
         db.session.add(db_record)
         db.session.commit()
 
+        # Governing: SPEC-0003 REQ "API Contract" — response MUST include overall_score
+        # (int 0-100), breakdown (four dimension scores), issues_detected (array)
         return {
             "overall_score": int(db_record.overall_score),
             "breakdown": {
@@ -69,6 +76,7 @@ def validate_data_quality(args):
             "issues_detected": db_record.issues_detected or [],
         }
     except Exception as exc:
+        # Governing: SPEC-0003 REQ "ORM Persistence" Scenario "Rollback on failure"
         db.session.rollback()
         return make_response(
             jsonify({"detail": f"Data validation failed: {exc}"}), 400

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -102,12 +102,14 @@ class QualityBreakdownSchema(Schema):
     timeliness = fields.Int(required=True)
 
 
+# Governing: SPEC-0003 REQ "Issue Object Schema" — exactly three fields; severity is plain string
 class IssueSchema(Schema):
     field = fields.Str(required=True)
     issue = fields.Str(required=True)
     severity = fields.Str(required=True)
 
 
+# Governing: SPEC-0003 REQ "API Contract" — overall_score int 0-100, breakdown, issues_detected
 class DataQualityOutputSchema(Schema):
     overall_score = fields.Int(required=True)
     breakdown = fields.Nested(QualityBreakdownSchema, required=True)


### PR DESCRIPTION
## Summary

- Added `# Governing: SPEC-0003 REQ "..."` comments to `backend/api/validation.py`, tracing: the module docstring, issue severity serialization, ORM persistence block, the response return, and the rollback on failure handler
- Added `# Governing: SPEC-0003 REQ "..."` comments to `IssueSchema` and `DataQualityOutputSchema` in `backend/schemas.py`

All 14 existing tests pass.

**Note**: This PR is comment-only (14 lines) because it is the last issue in the SPEC-0003 queue and no additional work could be bundled.

## Test plan

- [x] All 14 tests in `tests/test_api.py` pass (no logic changes, comment-only)
- [x] Governing comments reference the correct SPEC-0003 requirements

Closes #21
Part of #19
Governing: SPEC-0003

🤖 Generated with [Claude Code](https://claude.com/claude-code)